### PR TITLE
Remove outstanding event listeners when component unmounts

### DIFF
--- a/src/Alpha.jsx
+++ b/src/Alpha.jsx
@@ -24,6 +24,10 @@ export default class Alpha extends React.Component {
     });
   }
 
+  componentWillUnmount() {
+    this.removeListeners();
+  }
+
   onMouseDown(e) {
     const x = e.clientX;
     const y = e.clientY;
@@ -50,14 +54,7 @@ export default class Alpha extends React.Component {
     this.pointMoveTo({
       x, y,
     });
-    if (this.dragListener) {
-      this.dragListener.remove();
-      this.dragListener = null;
-    }
-    if (this.dragUpListener) {
-      this.dragUpListener.remove();
-      this.dragUpListener = null;
-    }
+    this.removeListeners();
   }
 
   getBackground() {
@@ -83,6 +80,17 @@ export default class Alpha extends React.Component {
     const alpha = Math.floor(left / width * 100);
 
     this.props.onChange(alpha);
+  }
+
+  removeListeners() {
+    if (this.dragListener) {
+      this.dragListener.remove();
+      this.dragListener = null;
+    }
+    if (this.dragUpListener) {
+      this.dragUpListener.remove();
+      this.dragUpListener = null;
+    }
   }
 
   render() {

--- a/src/Board.jsx
+++ b/src/Board.jsx
@@ -21,6 +21,10 @@ export default class Board extends React.Component {
     });
   }
 
+  componentWillUnmount() {
+    this.removeListeners();
+  }
+
   onBoardMouseDown(e) {
     const x = e.clientX;
     const y = e.clientY;
@@ -48,6 +52,14 @@ export default class Board extends React.Component {
       x,
       y,
     });
+    this.removeListeners();
+  }
+
+  getPrefixCls() {
+    return this.props.rootPrefixCls + '-board';
+  }
+
+  removeListeners() {
     if (this.dragListener) {
       this.dragListener.remove();
       this.dragListener = null;
@@ -56,10 +68,6 @@ export default class Board extends React.Component {
       this.dragUpListener.remove();
       this.dragUpListener = null;
     }
-  }
-
-  getPrefixCls() {
-    return this.props.rootPrefixCls + '-board';
   }
 
   /**

--- a/src/Ribbon.jsx
+++ b/src/Ribbon.jsx
@@ -20,6 +20,10 @@ export default class Ribbon extends React.Component {
     });
   }
 
+  componentWillUnmount() {
+    this.removeListeners();
+  }
+
   onMouseDown(e) {
     const x = e.clientX;
     const y = e.clientY;
@@ -46,14 +50,7 @@ export default class Ribbon extends React.Component {
     this.pointMoveTo({
       x, y,
     });
-    if (this.dragListener) {
-      this.dragListener.remove();
-      this.dragListener = null;
-    }
-    if (this.dragUpListener) {
-      this.dragUpListener.remove();
-      this.dragUpListener = null;
-    }
+    this.removeListeners();
   }
 
   getPrefixCls() {
@@ -74,6 +71,17 @@ export default class Ribbon extends React.Component {
       h: hue,
     };
     this.props.onChange(hsv);
+  }
+
+  removeListeners() {
+    if (this.dragListener) {
+      this.dragListener.remove();
+      this.dragListener = null;
+    }
+    if (this.dragUpListener) {
+      this.dragUpListener.remove();
+      this.dragUpListener = null;
+    }
   }
 
   render() {


### PR DESCRIPTION
This PR fixed a bug when color picker component is unmounted while dragging is in progress. We need to remove existing event listeners to prevent **findDOMNode was called on an unmounted component** error