### PR TITLE
fix: parse of fast-color

### DIFF
--- a/src/color.ts
+++ b/src/color.ts
@@ -5,6 +5,10 @@ import type { ColorGenInput, HSB } from './interface';
 export const getRoundNumber = (value: number) => Math.round(Number(value || 0));
 
 const convertHsb2Hsv = (color: ColorGenInput): ColorInput => {
+  if (color instanceof FastColor) {
+    return color;
+  }
+
   if (color && typeof color === 'object' && 'h' in color && 'b' in color) {
     const { b, ...resets } = color as HSB;
     return {

--- a/tests/color.test.tsx
+++ b/tests/color.test.tsx
@@ -1,0 +1,10 @@
+import { Color } from '../src';
+
+describe('ColorPicker.Color', () => {
+  it('Not break of color', () => {
+    const oriColor = new Color('#FF0000');
+    const nextColor = new Color(oriColor);
+
+    expect(oriColor.toHexString()).toEqual(nextColor.toHexString());
+  });
+});


### PR DESCRIPTION
TinyColor 里所有数据都是内联变量，所以在转化时会当成对象来出来。但是 FastColor 是计算数值，导致会出现转换报错。加一个对象判断做跳过。