### PR TITLE
fix: make clickable color blocks keyboard accessible

### DIFF
--- a/src/components/ColorBlock.tsx
+++ b/src/components/ColorBlock.tsx
@@ -30,7 +30,9 @@ const ColorBlock: React.FC<ColorBlockProps> = ({
       ? event => {
           if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            event.currentTarget.click();
+            if (!event.repeat) {
+              event.currentTarget.click();
+            }
           }
         }
       : undefined;

--- a/src/components/ColorBlock.tsx
+++ b/src/components/ColorBlock.tsx
@@ -10,6 +10,7 @@ export type ColorBlockProps = {
   innerClassName?: string;
   /** Internal usage. Only used in antd ColorPicker semantic structure only */
   innerStyle?: React.CSSProperties;
+  'aria-label'?: string;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
 };
 
@@ -20,14 +21,29 @@ const ColorBlock: React.FC<ColorBlockProps> = ({
   style,
   innerClassName,
   innerStyle,
+  'aria-label': ariaLabel,
   onClick,
 }) => {
   const colorBlockCls = `${prefixCls}-color-block`;
+  const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> | undefined =
+    onClick
+      ? event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            event.currentTarget.click();
+          }
+        }
+      : undefined;
+
   return (
     <div
+      aria-label={onClick ? (ariaLabel ?? color) : undefined}
       className={clsx(colorBlockCls, className)}
       style={style}
       onClick={onClick}
+      onKeyDown={onKeyDown}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
     >
       <div
         className={clsx(`${colorBlockCls}-inner`, innerClassName)}

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -67,8 +67,38 @@ describe('ColorPicker.Components', () => {
       />,
     );
 
+    const colorBlock = container.querySelector('.test-color-block');
     const innerDiv = container.querySelector('.test-color-block-inner');
+    expect(colorBlock).not.toHaveAttribute('role');
+    expect(colorBlock).not.toHaveAttribute('tabindex');
+    expect(colorBlock).not.toHaveAttribute('aria-label');
     expect(innerDiv).toHaveClass('my-inner-class');
     expect(innerDiv).toHaveStyle({ color: '#903' });
+  });
+
+  it('makes clickable ColorBlock keyboard accessible', () => {
+    const onClick = vi.fn();
+    const { getByRole } = render(
+      <ColorBlock
+        prefixCls="test"
+        color="#ff0000"
+        aria-label="Brand red"
+        onClick={onClick}
+      />,
+    );
+    const button = getByRole('button', { name: 'Brand red' });
+
+    fireEvent.keyDown(button, { key: 'Enter' });
+    fireEvent.keyDown(button, { key: ' ' });
+
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the color value as the default name for clickable ColorBlock', () => {
+    const { getByRole } = render(
+      <ColorBlock prefixCls="test" color="#ff0000" onClick={() => {}} />,
+    );
+
+    expect(getByRole('button', { name: '#ff0000' })).toBeInTheDocument();
   });
 });

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -90,6 +90,7 @@ describe('ColorPicker.Components', () => {
 
     fireEvent.keyDown(button, { key: 'Enter' });
     fireEvent.keyDown(button, { key: ' ' });
+    fireEvent.keyDown(button, { key: 'Enter', repeat: true });
 
     expect(onClick).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Summary

- expose clickable `ColorBlock` instances as focusable buttons
- support Enter and Space activation without changing non-clickable blocks
- provide the color value as the default accessible name and allow an explicit `aria-label` override

## Why

Ant Design uses the exported `ColorBlock` with `onClick` for ColorPicker preset swatches. The component currently renders a mouse-only `div`: it has no interactive role, no tab stop, no accessible name, and no keyboard activation path.

The regression test was run against exact upstream `f6a0287` before the implementation and failed because Testing Library could not find a button named `#ff0000`.

## Validation

- `npm test` — 3 files, 23 tests passed
- `npm run tsc` — passed
- focused ESLint on `src/components/ColorBlock.tsx` — passed
- Prettier check on changed files — passed
- `git diff --check` — passed

The repository-wide lint command reports one pre-existing warning in `src/hooks/useColorDrag.ts` (`react-hooks/exhaustive-deps`) and no errors; this PR does not touch that file.

AI assistance disclosure: Codex was used to trace the Ant Design call site, audit open issues and PRs for overlap, implement the focused fix, and run validation. The failing baseline and green results above were verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * `ColorBlock` 支持自定义无障碍标签。
  * 可点击的颜色块支持通过 Enter 或空格键触发点击。
  * 未提供标签时，自动使用颜色值作为默认名称。
* **改进**
  * 防止长按键盘按键导致重复触发点击。
  * 不可点击的颜色块不再添加多余的交互和无障碍属性。
  * 提升颜色块对键盘用户及辅助技术用户的可访问性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->